### PR TITLE
:recycle: refact: update README and version info; improve cleanup logic in fake-tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ fake-tty is a tool that runs commands in a pseudo terminal (pty), making them be
 
 ## Requirements
 
+- Linux (This program is Linux-only and does not support other operating systems.)
 - C compiler (e.g., `gcc 4.0+`)
 - C Standard Library (e.g., `glibc 2.3+`)
 - Make utility

--- a/fake-tty.c
+++ b/fake-tty.c
@@ -37,7 +37,7 @@ static const char version_info[] = "@(#)$Header: fake-tty 0.5.0 2002-03-18/2025-
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
-#define PERROR(msg) perror( __FILE__ ":" TOSTRING(__LINE__) ": " msg )
+#define PERROR(msg) do { perror( __FILE__ ":" TOSTRING(__LINE__) ": " msg ); } while (0)
 
 #define EXIT_FAILURE_PARENT 1
 #define EXIT_FAILURE_CHILD 2

--- a/fake-tty.c
+++ b/fake-tty.c
@@ -16,7 +16,7 @@
  *
  * @copyright Copyright (C) 2002-2025 SATO, Yoshiyuki
  */
-static const char version_info[] = "@(#)$Header: fake-tty 0.4.0 2002-03-18/2025-06-18 yoshi389111 Exp $";
+static const char version_info[] = "@(#)$Header: fake-tty 0.5.0 2002-03-18/2025-06-19 yoshi389111 Exp $";
 
 #define _XOPEN_SOURCE 600 // POSIX.1-2001
 
@@ -35,6 +35,10 @@ static const char version_info[] = "@(#)$Header: fake-tty 0.4.0 2002-03-18/2025-
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define PERROR(msg) perror( __FILE__ ":" TOSTRING(__LINE__) ": " msg )
+
 #define EXIT_FAILURE_PARENT 1
 #define EXIT_FAILURE_CHILD 2
 #define EXIT_COMMAND_NOT_FOUND 127
@@ -42,17 +46,16 @@ static const char version_info[] = "@(#)$Header: fake-tty 0.4.0 2002-03-18/2025-
 
 /** Flag for window size change. */
 volatile sig_atomic_t g_winch_flag = 0;
-
 /** Flag for exit signal. */
 volatile sig_atomic_t g_exit_flag = 0;
 /** Exit signal number. */
 volatile sig_atomic_t g_exit_signo = 0;
 
 /** Original terminal settings for restoring later. */
-struct termios orig_term_info;
+struct termios g_orig_termios;
 
 /** Flag indicating whether the terminal needs to be restored. */
-int g_restore_term_info = 0;
+int g_is_term_restore_needed = 0;
 
 /** master file descriptor, used in cleanup() */
 int g_master_fd = -1;
@@ -60,15 +63,24 @@ int g_master_fd = -1;
 /** slave file descriptor, used in cleanup() */
 int g_slave_fd = -1;
 
+/** Flag indicating whether the current process is the child process. */
+int g_in_child = 0;
+
 /**
  * @brief Cleans up file descriptors and restores terminal settings if needed.
  */
 void cleanup()
 {
-    if (g_restore_term_info) {
-        // restore original terminal settings
-        tcsetattr(STDIN_FILENO, TCSANOW, &orig_term_info);
-        g_restore_term_info = 0;
+    if (g_in_child) {
+        // close the duplicated pseudo-terminal (only in child process)
+        close(STDIN_FILENO);
+        close(STDOUT_FILENO);
+        close(STDERR_FILENO);
+
+    } else if (g_is_term_restore_needed) {
+        // restore original terminal settings (only in parent process)
+        tcsetattr(STDIN_FILENO, TCSANOW, &g_orig_termios);
+        g_is_term_restore_needed = 0;
     }
 
     if (g_master_fd != -1) {
@@ -83,14 +95,40 @@ void cleanup()
 }
 
 /**
- * @brief Closes file descriptors and exits with the given code.
+ * @brief Checks for exit signal and cleans up if needed.
  *
- * @param exit_code Exit status code.
+ * This function should be called periodically in the main loop to check if an exit signal has been received.
+ * If so, it cleans up resources and raises the signal again to terminate the process.
  */
-void cleanup_and_exit(int exit_code)
+void check_exit_signal()
 {
-    cleanup();
-    exit(exit_code);
+    if (g_exit_flag) {
+        cleanup();
+        signal(g_exit_signo, SIG_DFL);
+        raise(g_exit_signo);
+    }
+}
+
+/**
+ * @brief Propagates window size changes from the parent terminal to the child pty.
+ * Called on SIGWINCH in the parent process.
+ *
+ * @param signo Signal number (unused).
+ */
+void handle_sigwinch(int signo __attribute__((unused)))
+{
+    g_winch_flag = 1;
+}
+
+/**
+ * @brief Signal handler to restore terminal settings and exit.
+ *
+ * @param signo Signal number.
+ */
+void handle_exit_signal(int signo)
+{
+    g_exit_flag = 1;
+    g_exit_signo = signo;
 }
 
 /**
@@ -101,10 +139,11 @@ void cleanup_and_exit(int exit_code)
  * @param buffsize Size of the buffer.
  * @return Number of bytes read, 0 on EOF.
  */
-ssize_t read_from_fd(int fd_in, char *buff, size_t buffsize)
+ssize_t read_data(int fd_in, char *buff, size_t buffsize)
 {
     ssize_t ret;
     do {
+        check_exit_signal();
         ret = read(fd_in, buff, buffsize);
     } while (ret == -1 && errno == EINTR);
 
@@ -114,8 +153,8 @@ ssize_t read_from_fd(int fd_in, char *buff, size_t buffsize)
         if (errno == EIO) {
             return 0; // EOF
         }
-        perror("read()");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("read()");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     return ret;
@@ -129,12 +168,13 @@ ssize_t read_from_fd(int fd_in, char *buff, size_t buffsize)
  * @param len Length of data to write.
  * @return Number of bytes written, 0 on EOF.
  */
-ssize_t write_to_fd(int fd_out, const char *buff, ssize_t len)
+ssize_t write_data(int fd_out, const char *buff, ssize_t len)
 {
     ssize_t written = 0;
     while (written < len) {
         ssize_t ret;
         do {
+            check_exit_signal();
             ret = write(fd_out, buff + written, len - written);
         } while (ret == -1 && errno == EINTR);
 
@@ -147,8 +187,8 @@ ssize_t write_to_fd(int fd_out, const char *buff, ssize_t len)
             if (errno == EIO) {
                 return 0; // EOF
             }
-            perror("write()");
-            cleanup_and_exit(EXIT_FAILURE_PARENT);
+            PERROR("write()");
+            exit(EXIT_FAILURE_PARENT);
         }
         written += ret;
     }
@@ -162,42 +202,18 @@ ssize_t write_to_fd(int fd_out, const char *buff, ssize_t len)
  * @param fd_out File descriptor for output.
  * @return 1 on success, 0 on EOF.
  */
-int relay_fd_data(int fd_in, int fd_out)
+int relay_data(int fd_in, int fd_out)
 {
     char buff[BUFFSIZE];
-    ssize_t len = read_from_fd(fd_in, buff, sizeof(buff));
+    ssize_t len = read_data(fd_in, buff, sizeof(buff));
     if (len == 0) {
         return 0; // EOF
     }
 
-    if (write_to_fd(fd_out, buff, len) == 0) {
+    if (write_data(fd_out, buff, len) == 0) {
         return 0; // EOF
     }
     return 1; // success
-}
-
-/**
- * @brief Cleans up file descriptors and exits the child process with the given code.
- *
- * @param exit_code Exit status code.
- */
-void cleanup_and_exit_child(int exit_code)
-{
-    close(STDIN_FILENO);
-    close(STDOUT_FILENO);
-    close(STDERR_FILENO);
-
-    if (g_master_fd != -1) {
-        close(g_master_fd);
-        g_master_fd = -1;
-    }
-
-    if (g_slave_fd != -1) {
-        close(g_slave_fd);
-        g_slave_fd = -1;
-    }
-
-    exit(exit_code);
 }
 
 /**
@@ -209,45 +225,51 @@ void child_side(char* argv[])
 {
     // new session leader
     if (setsid() == -1) {
-        perror("setsid()");
-        cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+        PERROR("setsid()");
+        exit(EXIT_FAILURE_CHILD);
     }
 
     // set controlling terminal
     if (ioctl(g_slave_fd, TIOCSCTTY, 0) == -1) {
-        perror("ioctl(TIOCSCTTY)");
-        cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+        PERROR("ioctl(TIOCSCTTY)");
+        exit(EXIT_FAILURE_CHILD);
+    }
+
+    // set foreground process group
+    if (tcsetpgrp(g_slave_fd, getpid()) == -1) {
+        PERROR("tcsetpgrp()");
+        exit(EXIT_FAILURE_CHILD);
     }
 
     // slave -> stdin(child)
     if (dup2(g_slave_fd, STDIN_FILENO) == -1) {
-        perror("dup2(STDIN)");
-        cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+        PERROR("dup2(STDIN)");
+        exit(EXIT_FAILURE_CHILD);
     }
 
     // stdout(child) -> slave
     if (dup2(g_slave_fd, STDOUT_FILENO) == -1) {
-        perror("dup2(STDOUT)");
-        cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+        PERROR("dup2(STDOUT)");
+        exit(EXIT_FAILURE_CHILD);
     }
 
     // stderr(child) -> slave
     if (dup2(g_slave_fd, STDERR_FILENO) == -1) {
-        perror("dup2(STDERR)");
-        cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+        PERROR("dup2(STDERR)");
+        exit(EXIT_FAILURE_CHILD);
     }
 
     if (close(g_slave_fd) == -1) {
-        perror("close(slave)");
+        PERROR("close(slave)");
         g_slave_fd = -1;
-        cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+        exit(EXIT_FAILURE_CHILD);
     }
     g_slave_fd = -1;
 
-    // undocumented, but always argv[argc] == NULL
+    // undocumented specification, always argv[argc] == NULL
     execvp(argv[0], argv);
-    perror("execvp()");
-    cleanup_and_exit_child(EXIT_COMMAND_NOT_FOUND);
+    PERROR("execvp()");
+    exit(EXIT_COMMAND_NOT_FOUND);
 }
 
 /**
@@ -257,18 +279,14 @@ void child_side(char* argv[])
 void parent_side()
 {
     int maxfd = g_master_fd > STDIN_FILENO ? g_master_fd : STDIN_FILENO;
-    int stdin_eof = 0;
+    int is_stdin_closed = 0;
     while (1) {
-        if (g_exit_flag) {
-            cleanup();
-            signal(g_exit_signo, SIG_DFL);
-            raise(g_exit_signo);
-        }
+        check_exit_signal();
 
         fd_set fds;
         FD_ZERO(&fds);
         FD_SET(g_master_fd, &fds);
-        if (!stdin_eof) {
+        if (!is_stdin_closed) {
             FD_SET(STDIN_FILENO, &fds);
         }
 
@@ -277,8 +295,8 @@ void parent_side()
                 // interrupted by signal, retry select
                 continue;
             }
-            perror("select()");
-            cleanup_and_exit(EXIT_FAILURE_PARENT);
+            PERROR("select()");
+            exit(EXIT_FAILURE_PARENT);
         }
 
         if (g_winch_flag) {
@@ -287,8 +305,8 @@ void parent_side()
             if (ioctl(STDIN_FILENO, TIOCGWINSZ, &size_info) == 0) {
                 int fd_slave_for_winsz = open(ptsname(g_master_fd), O_WRONLY | O_NOCTTY);
                 if (fd_slave_for_winsz == -1) {
-                    perror("open(slave for winsz)");
-                    cleanup_and_exit(EXIT_FAILURE_PARENT);
+                    PERROR("open(slave for winsz)");
+                    exit(EXIT_FAILURE_PARENT);
                 }
                 ioctl(fd_slave_for_winsz, TIOCSWINSZ, &size_info);
                 close(fd_slave_for_winsz);
@@ -298,44 +316,22 @@ void parent_side()
 
         if (FD_ISSET(g_master_fd, &fds)) {
             // master -> stdout(parent)
-            if (relay_fd_data(g_master_fd, STDOUT_FILENO) == 0) {
+            if (relay_data(g_master_fd, STDOUT_FILENO) == 0) {
                 // EOF
                 break;
             }
         }
 
-        if (!stdin_eof && FD_ISSET(STDIN_FILENO, &fds)) {
+        if (!is_stdin_closed && FD_ISSET(STDIN_FILENO, &fds)) {
             // stdin(parent) -> master
-            if (relay_fd_data(STDIN_FILENO, g_master_fd) == 0) {
+            if (relay_data(STDIN_FILENO, g_master_fd) == 0) {
                 // EOF
-                stdin_eof = 1; // mark stdin EOF
+                is_stdin_closed = 1; // mark stdin EOF
             }
         }
     }
     close(g_master_fd);
     g_master_fd = -1;
-}
-
-/**
- * @brief Propagates window size changes from the parent terminal to the child pty.
- * Called on SIGWINCH in the parent process.
- *
- * @param signo Signal number (unused).
- */
-void sigwinch_handler(int signo __attribute__((unused)))
-{
-    g_winch_flag = 1;
-}
-
-/**
- * @brief Signal handler to restore terminal settings and exit.
- *
- * @param signo Signal number.
- */
-void sig_restore_handler(int signo)
-{
-    g_exit_flag = 1;
-    g_exit_signo = signo;
 }
 
 /**
@@ -347,151 +343,157 @@ void sig_restore_handler(int signo)
  */
 int main(int argc, char*argv[])
 {
+    // ensure cleanup on exit
+    atexit(cleanup);
+
     // check arguments
     if (argc < 2) {
         fprintf(stderr, "usage: %s command [args ...]\n", argv[0]);
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        exit(EXIT_FAILURE_PARENT);
     }
 
     // check help. -h or --help
     if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
         printf("usage: %s command [args ...]\n", argv[0]);
-        cleanup_and_exit(EXIT_SUCCESS);
+        exit(EXIT_SUCCESS);
     }
 
     // check version. -V/-v or --version
     if (strcasecmp(argv[1], "-V") == 0 || strcmp(argv[1], "--version") == 0) {
         printf("%s\n", version_info);
-        cleanup_and_exit(EXIT_SUCCESS);
+        exit(EXIT_SUCCESS);
     }
 
     // open pty-master
     g_master_fd = posix_openpt(O_RDWR);
     if (g_master_fd == -1) {
-        perror("open(master)");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("open(master)");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     // grant access to pty-slave
     if (grantpt(g_master_fd) == -1) {
-        perror("grantpt()");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("grantpt()");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     // unlock pty-slave
     if (unlockpt(g_master_fd) == -1) {
-        perror("unlockpt()");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("unlockpt()");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     // get pty-slave name
     char *slave_name = ptsname(g_master_fd);
     if (slave_name == NULL) {
-        perror("ptsname()");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("ptsname()");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     // open pty-slave
     g_slave_fd = open(slave_name, O_RDWR);
     if (g_slave_fd == -1) {
-        perror("open(slave)");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("open(slave)");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     if (isatty(STDIN_FILENO)) {
         // copy term info.
-        struct termios term_info;
-        if (tcgetattr(STDIN_FILENO, &term_info) == -1) {
-            perror("tcgetattr(STDIN)");
-            cleanup_and_exit(EXIT_FAILURE_PARENT);
+        struct termios termios;
+        if (tcgetattr(STDIN_FILENO, &termios) == -1) {
+            PERROR("tcgetattr(STDIN)");
+            exit(EXIT_FAILURE_PARENT);
         }
-        if (tcsetattr(g_slave_fd, TCSANOW, &term_info) == -1) {
-            perror("tcsetattr(slave)");
-            cleanup_and_exit(EXIT_FAILURE_PARENT);
+        if (tcsetattr(g_slave_fd, TCSANOW, &termios) == -1) {
+            PERROR("tcsetattr(slave)");
+            exit(EXIT_FAILURE_PARENT);
         }
 
         // copy win-size
         struct winsize size_info;
         if (ioctl(STDIN_FILENO, TIOCGWINSZ, &size_info) == -1) {
-            perror("ioctl(TIOCGWINSZ)");
-            cleanup_and_exit(EXIT_FAILURE_PARENT);
+            PERROR("ioctl(TIOCGWINSZ)");
+            exit(EXIT_FAILURE_PARENT);
         }
         if (ioctl(g_slave_fd, TIOCSWINSZ, &size_info) == -1) {
-            perror("ioctl(slave)");
-            cleanup_and_exit(EXIT_FAILURE_PARENT);
+            PERROR("ioctl(slave)");
+            exit(EXIT_FAILURE_PARENT);
         }
 
         // save original terminal settings
-        orig_term_info = term_info;
-        g_restore_term_info = 1;
+        g_orig_termios = termios;
+        g_is_term_restore_needed = 1;
 
         // set terminal to cbreak mode
-        struct termios cbreak_term_info = term_info;
-        cbreak_term_info.c_lflag &= ~(ICANON | ECHO);
-        cbreak_term_info.c_lflag |= ISIG;
-        if (tcsetattr(STDIN_FILENO, TCSANOW, &cbreak_term_info) == -1) {
-            perror("tcsetattr(STDIN)");
-            cleanup_and_exit(EXIT_FAILURE_PARENT);
+        struct termios cbreak_termios = termios;
+        cbreak_termios.c_lflag &= ~(ICANON | ECHO);
+        cbreak_termios.c_lflag |= ISIG;
+        if (tcsetattr(STDIN_FILENO, TCSANOW, &cbreak_termios) == -1) {
+            PERROR("tcsetattr(STDIN)");
+            exit(EXIT_FAILURE_PARENT);
         }
     }
 
     // Set up signal handler (parent process only)
     struct sigaction sa_winch;
     memset(&sa_winch, 0, sizeof(sa_winch));
-    sa_winch.sa_handler = sigwinch_handler;
+    sa_winch.sa_handler = handle_sigwinch;
     sigemptyset(&sa_winch.sa_mask);
     sa_winch.sa_flags = 0;
     if (sigaction(SIGWINCH, &sa_winch, NULL) == -1) {
-        perror("sigaction(SIGWINCH)");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("sigaction(SIGWINCH)");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     struct sigaction sa_restore;
     memset(&sa_restore, 0, sizeof(sa_restore));
-    sa_restore.sa_handler = sig_restore_handler;
+    sa_restore.sa_handler = handle_exit_signal;
     sigemptyset(&sa_restore.sa_mask);
     sa_restore.sa_flags = 0;
     if (sigaction(SIGINT,  &sa_restore, NULL) == -1) {
-        perror("sigaction(SIGINT)");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("sigaction(SIGINT)");
+        exit(EXIT_FAILURE_PARENT);
     }
     if (sigaction(SIGTERM, &sa_restore, NULL) == -1) {
-        perror("sigaction(SIGTERM)");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("sigaction(SIGTERM)");
+        exit(EXIT_FAILURE_PARENT);
     }
     if (sigaction(SIGHUP,  &sa_restore, NULL) == -1) {
-        perror("sigaction(SIGHUP)");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("sigaction(SIGHUP)");
+        exit(EXIT_FAILURE_PARENT);
     }
     if (sigaction(SIGQUIT, &sa_restore, NULL) == -1) {
-        perror("sigaction(SIGQUIT)");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("sigaction(SIGQUIT)");
+        exit(EXIT_FAILURE_PARENT);
     }
 
     pid_t pid = fork();
     if (pid == -1) {
-        perror("fork()");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("fork()");
+        exit(EXIT_FAILURE_PARENT);
+
     } else if (pid == 0) {
         // child process side
-        g_restore_term_info = 0; // child does not need to restore terminal
+        g_in_child = 1; // mark as child side
+        g_is_term_restore_needed = 0; // child does not need to restore terminal
+
         if (close(g_master_fd) == -1) {
-            perror("close(master)");
+            PERROR("close(master)");
             g_master_fd = -1;
-            cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+            exit(EXIT_FAILURE_CHILD);
         }
         g_master_fd = -1;
         // skip argv[0] (program name)
         child_side(argv + 1);
         // UNREACHABLE
-        cleanup_and_exit_child(EXIT_FAILURE_CHILD);
+        exit(EXIT_FAILURE_CHILD);
     }
 
     // parent process side
     if (close(g_slave_fd) == -1) {
-        perror("close(slave)");
+        PERROR("close(slave)");
         g_slave_fd = -1;
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        exit(EXIT_FAILURE_PARENT);
     }
     g_slave_fd = -1;
 
@@ -504,15 +506,15 @@ int main(int argc, char*argv[])
     // and exit with its status
     int status;
     if (waitpid(pid, &status, 0) == -1) {
-        perror("waitpid()");
-        cleanup_and_exit(EXIT_FAILURE_PARENT);
+        PERROR("waitpid()");
+        exit(EXIT_FAILURE_PARENT);
     }
     if (WIFEXITED(status)) {
-        cleanup_and_exit(WEXITSTATUS(status));
+        exit(WEXITSTATUS(status));
     } else if (WIFSIGNALED(status)) {
         // exit code 128 + signal number
-        cleanup_and_exit(128 + WTERMSIG(status));
+        exit(128 + WTERMSIG(status));
     }
     // UNREACHABLE
-    cleanup_and_exit(EXIT_FAILURE_PARENT);
+    exit(EXIT_FAILURE_PARENT);
 }


### PR DESCRIPTION
This pull request refactors the `fake-tty` program to improve code readability, streamline error handling, and enhance maintainability. Key changes include replacing repetitive error-handling code with a macro, consolidating cleanup logic, and introducing new signal handlers for better process management.

### Code Refactoring and Cleanup:
* Replaced repetitive `perror` calls with the `PERROR` macro to simplify error reporting and include file and line information. (`fake-tty.c`) [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R38-R83) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L117-R157) [[3]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L132-R177) [[4]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L212-R272) [[5]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L260-R289) [[6]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R346-R496) [[7]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L507-R519)
* Consolidated cleanup logic into a single `cleanup()` function, removing redundant `cleanup_and_exit` functions. (`fake-tty.c`) [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L86-R131) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L104-R146)

### Signal Handling Improvements:
* Introduced `handle_sigwinch` and `handle_exit_signal` functions to manage window size changes and exit signals more effectively. (`fake-tty.c`) [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L86-R131) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L104-R146)

### Function Renaming for Clarity:
* Renamed functions like `read_from_fd` to `read_data`, `write_to_fd` to `write_data`, and `relay_fd_data` to `relay_data` for better readability and alignment with their purpose. (`fake-tty.c`) [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L117-R157) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L132-R177) [[3]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L165-L202) [[4]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L301-L340)

### Variable Renaming for Consistency:
* Updated variable names (e.g., `stdin_eof` to `is_stdin_closed`, `orig_term_info` to `g_orig_termios`) for consistency and clarity. (`fake-tty.c`) [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R38-R83) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L260-R289)

### Version Update:
* Updated the version information from `0.4.0` to `0.5.0` to reflect the changes in functionality. (`fake-tty.c`)