### PR TITLE
:recycle: refact: update README and improve code structure; change version to 0.5.2; enhance readability and organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fake-tty
+# Fake tty command for Linux
 
 ## Overview
 
@@ -25,11 +25,11 @@ cd fake-tty
 make
 ```
 
-If necessary, move `fake-tty` to a bin directory that is defined in your `PATH` environment variable.
+If necessary, move `fake-tty` to a directory in your `PATH`.
 
 ## Usage
 
-```sh
+```txt
 fake-tty <command> [args...]
 ```
 

--- a/fake-tty.c
+++ b/fake-tty.c
@@ -430,7 +430,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    // open pty-master, pty-slave
+    // open pty master/slave and set terminal attributes and window size if attached to a terminal
     if (openpty(&g_master_fd, &g_slave_fd, NULL, p_termios, p_size_info) == -1) {
         PERROR("openpty()");
         exit(EXIT_FAILURE_PARENT);


### PR DESCRIPTION
This pull request introduces several updates to the `fake-tty` project, including documentation improvements, code refactoring, and functional enhancements. The most significant changes involve replacing manual pseudo-terminal setup with `openpty` for better maintainability, updating global variables to static for improved encapsulation, and refining the version-check logic. Additionally, the documentation has been clarified and streamlined.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated the project title for clarity and simplified instructions related to moving the `fake-tty` binary to a directory in the `PATH` environment variable. Changed usage example formatting from `sh` to `txt` for consistency. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R32)

### Code refactoring:
* [`fake-tty.c`](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L389-R417): Replaced manual pseudo-terminal setup (`posix_openpt`, `grantpt`, `unlockpt`, etc.) with `openpty`, simplifying the code and reducing potential errors. [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L389-R417) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R433-R440)
* [`fake-tty.c`](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L19-R71): Updated global variables (`g_winch_flag`, `g_exit_flag`, `g_exit_signo`, etc.) to `static` for better encapsulation and reduced risk of unintended external access.

### Functional enhancements:
* [`fake-tty.c`](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L389-R417): Refined version-check logic to support additional flags (`-v`, `--version`) for improved usability.

These changes collectively improve the project's maintainability, usability, and overall code quality.