### PR TITLE
Refactor fake-tty.c: Improve Readability, Maintainability, and Terminal FD Handling

### DIFF
--- a/fake-tty.c
+++ b/fake-tty.c
@@ -301,7 +301,7 @@ void check_win_size_change()
         // handle window size change
         struct winsize size_info;
         if (ioctl(STDIN_FILENO, TIOCGWINSZ, &size_info) == 0) {
-            int fd_slave_for_winsz = open(ptsname(g_master_fd), O_WRONLY | O_NOCTTY);
+            int fd_slave_for_winsz = open(ptsname(g_master_fd), O_RDWR | O_NOCTTY);
             if (fd_slave_for_winsz == -1) {
                 PERROR("open(slave for winsz)");
                 exit(EXIT_FAILURE_PARENT);

--- a/fake-tty.c
+++ b/fake-tty.c
@@ -47,11 +47,15 @@ static const char version_info[] = "@(#)$Header: fake-tty 0.5.2 2002-03-18/2025-
 #define EXIT_COMMAND_NOT_FOUND 127
 /** @brief Buffer size for I/O operations. */
 #define BUFFSIZE 1024
+/** @brief Truthy value for boolean expressions. */
+#define TRUE 1
+/** @brief Falsy value for boolean expressions. */
+#define FALSE 0
 
 /** @brief Flag for window size change. */
-static volatile sig_atomic_t g_winch_flag = 0;
+static volatile sig_atomic_t g_winch_flag = FALSE;
 /** @brief Flag for exit signal. */
-static volatile sig_atomic_t g_exit_flag = 0;
+static volatile sig_atomic_t g_exit_flag = FALSE;
 /** @brief Exit signal number. */
 static volatile sig_atomic_t g_exit_signo = 0;
 
@@ -59,7 +63,7 @@ static volatile sig_atomic_t g_exit_signo = 0;
 static struct termios g_orig_termios;
 
 /** @brief Flag indicating whether the terminal needs to be restored. */
-static int g_is_term_restore_needed = 0;
+static int g_is_term_restore_needed = FALSE;
 
 /** @brief master file descriptor. */
 static int g_master_fd = -1;
@@ -68,7 +72,32 @@ static int g_master_fd = -1;
 static int g_slave_fd = -1;
 
 /** @brief Flag indicating whether the current process is the child process. */
-static int g_in_child = 0;
+static int g_in_child = FALSE;
+
+/** @brief File descriptor for the original terminal (if needed). */
+static int g_term_fd = -1;
+
+/** @brief Closes the master file descriptor. */
+int close_master_fd()
+{
+    if (g_master_fd != -1) {
+        int ret = close(g_master_fd);
+        g_master_fd = -1;
+        return ret;
+    }
+    return 0;
+}
+
+/** @brief Closes the slave file descriptor. */
+int close_slave_fd()
+{
+    if (g_slave_fd != -1) {
+        int ret = close(g_slave_fd);
+        g_slave_fd = -1;
+        return ret;
+    }
+    return 0;
+}
 
 /**
  * @brief Cleans up file descriptors and restores terminal settings if needed.
@@ -81,21 +110,14 @@ void cleanup()
         close(STDOUT_FILENO);
         close(STDERR_FILENO);
 
-    } else if (g_is_term_restore_needed) {
+    } else if (g_is_term_restore_needed && g_term_fd != -1) {
         // restore original terminal settings (only in parent process)
-        tcsetattr(STDIN_FILENO, TCSANOW, &g_orig_termios);
-        g_is_term_restore_needed = 0;
+        tcsetattr(g_term_fd, TCSANOW, &g_orig_termios);
+        g_is_term_restore_needed = FALSE;
     }
 
-    if (g_master_fd != -1) {
-        close(g_master_fd);
-        g_master_fd = -1;
-    }
-
-    if (g_slave_fd != -1) {
-        close(g_slave_fd);
-        g_slave_fd = -1;
-    }
+    close_master_fd();
+    close_slave_fd();
 }
 
 /**
@@ -121,7 +143,7 @@ void check_exit_signal()
  */
 void handle_sigwinch(int signo __attribute__((unused)))
 {
-    g_winch_flag = 1;
+    g_winch_flag = TRUE;
 }
 
 /**
@@ -131,7 +153,7 @@ void handle_sigwinch(int signo __attribute__((unused)))
  */
 void handle_exit_signal(int signo)
 {
-    g_exit_flag = 1;
+    g_exit_flag = TRUE;
     g_exit_signo = signo;
 }
 
@@ -145,7 +167,7 @@ void handle_exit_signal(int signo)
  */
 ssize_t read_data(int fd_in, char *buff, size_t buffsize)
 {
-    while (1) {
+    while (TRUE) {
         check_exit_signal();
 
         ssize_t ret = read(fd_in, buff, buffsize);
@@ -274,12 +296,10 @@ void child_side(char *argv[])
         exit(EXIT_FAILURE_CHILD);
     }
 
-    if (close(g_slave_fd) == -1) {
+    if (close_slave_fd() == -1) {
         PERROR("close(slave)");
-        g_slave_fd = -1;
         exit(EXIT_FAILURE_CHILD);
     }
-    g_slave_fd = -1;
 
     // undocumented specification, always argv[argc] == NULL
     execvp(argv[0], argv);
@@ -300,7 +320,7 @@ void check_win_size_change()
     if (g_winch_flag) {
         // handle window size change
         struct winsize size_info;
-        if (ioctl(STDIN_FILENO, TIOCGWINSZ, &size_info) == 0) {
+        if (ioctl(g_term_fd, TIOCGWINSZ, &size_info) == 0) {
             int fd_slave_for_winsz = open(ptsname(g_master_fd), O_RDWR | O_NOCTTY);
             if (fd_slave_for_winsz == -1) {
                 PERROR("open(slave for winsz)");
@@ -309,7 +329,7 @@ void check_win_size_change()
             ioctl(fd_slave_for_winsz, TIOCSWINSZ, &size_info);
             close(fd_slave_for_winsz);
         }
-        g_winch_flag = 0; // reset flag
+        g_winch_flag = FALSE; // reset flag
     }
 }
 
@@ -319,7 +339,7 @@ void check_win_size_change()
  */
 void parent_side()
 {
-    int is_stdin_closed = 0;
+    int is_stdin_closed = FALSE;
     while (1) {
         check_exit_signal();
         check_win_size_change();
@@ -356,12 +376,46 @@ void parent_side()
         if (!is_stdin_closed && (pfds[1].revents & (POLLIN | POLLHUP | POLLERR)) != 0) {
             if (relay_data(STDIN_FILENO, g_master_fd) == 0) {
                 // EOF or error
-                is_stdin_closed = 1;
+                is_stdin_closed = TRUE;
             }
         }
     }
-    close(g_master_fd);
-    g_master_fd = -1;
+    close_master_fd();
+}
+
+/**
+ * @brief Retrieve the terminal file descriptor.
+ *
+ * @return File descriptor for the terminal, or -1 if no terminal is available.
+ */
+int get_term_fd() {
+    if (isatty(STDIN_FILENO)) {
+        return STDIN_FILENO;
+    } else if (isatty(STDOUT_FILENO)) {
+        return STDOUT_FILENO;
+    } else if (isatty(STDERR_FILENO)) {
+        return STDERR_FILENO;
+    } else {
+        return -1;
+    }
+}
+
+/**
+ * @brief Sets the terminal to cbreak mode.
+ *
+ * In cbreak mode, input is available immediately without waiting for a newline,
+ * and input characters are not echoed to the terminal.
+ */
+void set_cbreak_mode()
+{
+    struct termios cbreak_termios = g_orig_termios;
+    cbreak_termios.c_lflag &= ~(ICANON | ECHO);
+    cbreak_termios.c_lflag |= ISIG; // enable signals like SIGINT
+    if (tcsetattr(g_term_fd, TCSANOW, &cbreak_termios) == -1) {
+        PERROR("tcsetattr(STDIN)");
+        exit(EXIT_FAILURE_PARENT);
+    }
+    g_is_term_restore_needed = TRUE;
 }
 
 /**
@@ -398,45 +452,43 @@ int main(int argc, char *argv[])
         exit(EXIT_SUCCESS);
     }
 
-    struct termios termios = {0};
-    struct winsize size_info = {0};
-    struct termios *p_termios = NULL;
-    struct winsize *p_size_info = NULL;
+    // skip argv[0] (program name)
+    char **arg_start = argv + 1;
 
-    if (isatty(STDIN_FILENO)) {
-        if (tcgetattr(STDIN_FILENO, &termios) == -1) {
-            PERROR("tcgetattr(STDIN)");
-            exit(EXIT_FAILURE_PARENT);
-        }
-        if (ioctl(STDIN_FILENO, TIOCGWINSZ, &size_info) == -1) {
-            PERROR("ioctl(TIOCGWINSZ)");
-            exit(EXIT_FAILURE_PARENT);
-        }
+    g_term_fd = get_term_fd();
 
-        p_termios = &termios;
-        p_size_info = &size_info;
-
-        // save original terminal settings
-        g_orig_termios = termios;
-        g_is_term_restore_needed = 1;
-
-        // set terminal to cbreak mode
-        struct termios cbreak_termios = termios;
-        cbreak_termios.c_lflag &= ~(ICANON | ECHO);
-        cbreak_termios.c_lflag |= ISIG;
-        if (tcsetattr(STDIN_FILENO, TCSANOW, &cbreak_termios) == -1) {
-            PERROR("tcsetattr(STDIN)");
-            exit(EXIT_FAILURE_PARENT);
-        }
+    if (g_term_fd == -1) {
+        // If no terminal is connected,
+        // the pseudo terminal cannot be set up,
+        // so a normal exec is executed.
+        execvp(arg_start[0], arg_start);
+        PERROR("execvp()");
+        exit(EXIT_COMMAND_NOT_FOUND);
     }
 
-    // open pty master/slave and set terminal attributes and window size if attached to a terminal
-    if (openpty(&g_master_fd, &g_slave_fd, NULL, p_termios, p_size_info) == -1) {
+    // retrieve terminal attributes
+    if (tcgetattr(g_term_fd, &g_orig_termios) == -1) {
+        PERROR("tcgetattr()");
+        exit(EXIT_FAILURE_PARENT);
+    }
+
+    // retrieve window size
+    struct winsize size_info;
+    if (ioctl(g_term_fd, TIOCGWINSZ, &size_info) == -1) {
+        PERROR("ioctl(TIOCGWINSZ)");
+        exit(EXIT_FAILURE_PARENT);
+    }
+
+    // set terminal to cbreak mode
+    set_cbreak_mode();
+
+    // open pty master/slave
+    if (openpty(&g_master_fd, &g_slave_fd, NULL, &g_orig_termios, &size_info) == -1) {
         PERROR("openpty()");
         exit(EXIT_FAILURE_PARENT);
     }
 
-    // Set up signal handler (parent process only)
+    // Set up signal handler for window size changes
     struct sigaction sa_winch = {0};
     sa_winch.sa_handler = handle_sigwinch;
     sigemptyset(&sa_winch.sa_mask);
@@ -446,6 +498,7 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE_PARENT);
     }
 
+    // Set up signal handler for cleanup
     struct sigaction sa_restore = {0};
     sa_restore.sa_handler = handle_exit_signal;
     sigemptyset(&sa_restore.sa_mask);
@@ -474,28 +527,23 @@ int main(int argc, char *argv[])
 
     } else if (pid == 0) {
         // child process side
-        g_in_child = 1; // mark as child side
-        g_is_term_restore_needed = 0; // child does not need to restore terminal
+        g_in_child = TRUE; // mark as child side
+        g_is_term_restore_needed = FALSE; // child does not need to restore terminal
 
-        if (close(g_master_fd) == -1) {
+        if (close_master_fd() == -1) {
             PERROR("close(master)");
-            g_master_fd = -1;
             exit(EXIT_FAILURE_CHILD);
         }
-        g_master_fd = -1;
-        // skip argv[0] (program name)
-        child_side(argv + 1);
+        child_side(arg_start);
         // UNREACHABLE
         exit(EXIT_FAILURE_CHILD);
     }
 
     // parent process side
-    if (close(g_slave_fd) == -1) {
+    if (close_slave_fd() == -1) {
         PERROR("close(slave)");
-        g_slave_fd = -1;
         exit(EXIT_FAILURE_PARENT);
     }
-    g_slave_fd = -1;
 
     parent_side();
 


### PR DESCRIPTION
This pull request introduces several improvements to the `fake-tty.c` codebase, focusing on code readability, maintainability, and functionality. The changes include replacing magic constants with `TRUE` and `FALSE` macros for boolean values, adding helper functions for file descriptor management, and refactoring terminal handling logic. Additionally, new functionality has been introduced to retrieve and manage terminal file descriptors more robustly.

### Code readability and maintainability:

* **Boolean macros**: Added `TRUE` and `FALSE` macros to replace magic constants (`1` and `0`) for boolean expressions, improving code clarity. Updated all relevant flags and variables to use these macros. [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R50-R66) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L124-R146) [[3]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L134-R156) [[4]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L322-R342)

* **Helper functions for file descriptors**: Introduced `close_master_fd()` and `close_slave_fd()` functions to encapsulate file descriptor cleanup logic, reducing code duplication. [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L71-R100) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L277-L282)

### Terminal handling improvements:

* **Terminal file descriptor retrieval**: Added `get_term_fd()` to determine the appropriate terminal file descriptor (`STDIN_FILENO`, `STDOUT_FILENO`, or `STDERR_FILENO`) and handle cases where no terminal is available.

* **Cbreak mode management**: Added `set_cbreak_mode()` to configure the terminal in cbreak mode, ensuring immediate input availability and signal handling. This refactoring centralizes terminal mode changes.

### Functional updates:

* **Signal handling enhancements**: Updated signal handlers for window size changes (`handle_sigwinch`) and exit signals (`handle_exit_signal`) to use the new boolean macros. [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L124-R146) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L134-R156)

* **Improved pseudo-terminal setup**: Refactored `main()` to streamline pseudo-terminal setup, including retrieving terminal attributes and window size, and handling cases where no terminal is connected. [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L401-R491) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L477-L498)