### PR TITLE
:recycle: fix: update copyright year in LICENSE and README; improve v…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 SATO, Yoshiyuki
+Copyright (c) 2002 SATO, Yoshiyuki
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## NAME
 
-`fake-tty` \- run a command in a pseudo terminal (pty) for linux
+`fake-tty` - run a command in a pseudo terminal (pty) for linux
 
 ## SYNOPSIS
 
@@ -59,4 +59,4 @@ MIT License
 
 ## AUTHOR
 
-Copyright (c) 2002-2025 SATO, Yoshiyuki
+Copyright &copy; 2002-2025 SATO, Yoshiyuki


### PR DESCRIPTION
This pull request includes minor updates to the `LICENSE` and `README.md` files to correct formatting and copyright information.

Copyright updates:
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year from 2025 to 2002 to reflect the correct year.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62): Adjusted the copyright format under the `AUTHOR` section to use HTML entity `&copy;` for better rendering.

Formatting improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Fixed spacing in the `NAME` section to ensure consistent formatting of the description.…ersion information in fake-tty.c; enhance argument parsing and error handling