### PR TITLE
:sparkles: feat: update version to 0.7.1; implement send_eof_if_canonical function to handle EOF in canonical mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## SYNOPSIS
 
-`fake-tty <command> [args...]`
-
-`fake-tty [-h | --help | -v | -V | --version]`
+```shell
+fake-tty [-h | --help | -v | -V | --version] COMMAND [ARGS...]
+```
 
 ## DESCRIPTION
 
@@ -16,10 +16,11 @@
 
 ## OPTIONS
 
-| Option                | Description         |
-|-----------------------|--------------------|
-| \-h, --help           | Show help message  |
-| \-v, \-V, --version   | Show version info  |
+- `-h`, `--help`
+  - Show help message and exit.
+
+- `-v`, `-V`, `--version`
+  - Show version information and exit.
 
 ## EXAMPLES
 
@@ -57,6 +58,4 @@ Move `fake-tty` to a directory in your `PATH` if needed.
 
 MIT License
 
-## AUTHOR
-
-Copyright &copy; 2002-2025 SATO, Yoshiyuki
+&copy; 2002-2025 SATO, Yoshiyuki


### PR DESCRIPTION
This pull request introduces updates to the `README.md` documentation and enhancements to the `fake-tty.c` source code. The changes improve clarity in usage instructions, update version information, and add functionality to handle EOF signals in canonical mode.

### Code Enhancements:

* [`fake-tty.c`](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R302-R340): Added a new function, `send_eof_if_canonical`, to send an EOF signal to the master PTY when the slave PTY is in canonical mode. Integrated this functionality into the parent main loop to handle EOF scenarios more gracefully. [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R302-R340) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793R697)
* [`fake-tty.c`](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L19-R19): Updated the `version_info` string to reflect the new version (`0.7.1`).
* [`fake-tty.c`](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L85-R85): Improved usage and help messages to align with the updated syntax in the documentation (`COMMAND [ARGS ...]`). [[1]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L85-R85) [[2]](diffhunk://#diff-f57f2a166e1b3e648d91943d8e92d76bf67c111ead464aa3e672db50ff383793L96-R96)

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R23): Updated the usage syntax to use uppercase `COMMAND` and `ARGS` for consistency with industry standards and improved readability. Reformatted the options section for better clarity.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R61): Removed the "AUTHOR" section and consolidated copyright information for simplicity.

